### PR TITLE
Install `onlyoffice_logger_helper` via gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
 source 'https://rubygems.org'
-gem 'onlyoffice_logger_helper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_logger_helper.git'
+gem 'onlyoffice_logger_helper'
 gem 'onlyoffice_s3_wrapper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_s3_wrapper'
 gem 'onlyoffice_tcm_helper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_tcm_helper'
 gem 'ooxml_parser', git: 'https://github.com/ONLYOFFICE/ooxml_parser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,12 +14,6 @@ GIT
     palladium (0.3.4)
 
 GIT
-  remote: https://github.com/onlyoffice-testing-robot/onlyoffice_logger_helper.git
-  revision: 6719da93effe6152454f84ea1a3f7d95437d604b
-  specs:
-    onlyoffice_logger_helper (1.0.1)
-
-GIT
   remote: https://github.com/onlyoffice-testing-robot/onlyoffice_s3_wrapper
   revision: 68fe0b5900b5754832dd3e983a69d17659b01109
   specs:
@@ -63,6 +57,7 @@ GEM
     onlyoffice_file_helper (0.1.0)
       onlyoffice_logger_helper (~> 1)
       rubyzip (~> 1.0)
+    onlyoffice_logger_helper (1.0.2)
     parallel (1.19.1)
     parser (2.7.0.3)
       ast (~> 2.4.0)
@@ -99,7 +94,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  onlyoffice_logger_helper!
+  onlyoffice_logger_helper
   onlyoffice_s3_wrapper!
   onlyoffice_tcm_helper!
   ooxml_parser!


### PR DESCRIPTION
This product is stable, so no need to perform git installs