### PR TITLE
Add skip file empty(пустой слайд).ppt

### DIFF
--- a/data/static_data.rb
+++ b/data/static_data.rb
@@ -23,7 +23,7 @@ class StaticData
   NEW_FILES_DIR = "#{File.join(File.dirname(__FILE__), '/..')}/assets/files/new"
   BROKEN_FILES_DIR = "#{File.join(File.dirname(__FILE__), '/..')}/assets/files/broken"
 
-  EMPTY_FILES = ['empty(слайдов нет).ppt', 'empty.rtf', 'new.rtf'].freeze
+  EMPTY_FILES = ['empty(слайдов нет).ppt', 'empty.rtf', 'new.rtf', 'empty(пустой слайд).ppt'].freeze
 
   PROJECT_NAME = 'X2t testing'
   PALLADIUM_SERVER = 'palladium.teamlab.info'

--- a/spec/functional/presentation/ppt_to_pptx_functional_spec.rb
+++ b/spec/functional/presentation/ppt_to_pptx_functional_spec.rb
@@ -10,7 +10,6 @@ describe 'Conversion ppt files to pptx' do
   end
   (files - result_sets.map { |result_set| "ppt/#{result_set}" }).each do |file|
     it File.basename(file) do
-      skip if File.basename(file) == 'empty(пустой слайд).ppt'
       s3.download_file_by_name(file, @tmp_dir)
       @file_data = x2t.convert("#{@tmp_dir}/#{File.basename(file)}", :pptx)
       expect(File.exist?(@file_data[:tmp_filename])).to be_truthy

--- a/spec/functional/presentation/ppt_to_pptx_functional_spec.rb
+++ b/spec/functional/presentation/ppt_to_pptx_functional_spec.rb
@@ -10,6 +10,7 @@ describe 'Conversion ppt files to pptx' do
   end
   (files - result_sets.map { |result_set| "ppt/#{result_set}" }).each do |file|
     it File.basename(file) do
+      skip if File.basename(file) == 'empty(пустой слайд).ppt'
       s3.download_file_by_name(file, @tmp_dir)
       @file_data = x2t.convert("#{@tmp_dir}/#{File.basename(file)}", :pptx)
       expect(File.exist?(@file_data[:tmp_filename])).to be_truthy


### PR DESCRIPTION
The type check `with_data?` in the match `.to be_with_data` is not suitable for this file, since it is initially empty. A new spec will be created for such files.