### PR TITLE
revert onlyoffice_s3_wrapper 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ Encoding.default_internal = Encoding::UTF_8
 
 source 'https://rubygems.org'
 gem 'onlyoffice_logger_helper'
-gem 'onlyoffice_s3_wrapper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_s3_wrapper'
+gem 'onlyoffice_s3_wrapper', '0.2.0'
 gem 'onlyoffice_tcm_helper', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_tcm_helper'
 gem 'ooxml_parser'
 gem 'palladium', git: 'https://github.com/flaminestone/palladium.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,14 +5,6 @@ GIT
     palladium (0.3.4)
 
 GIT
-  remote: https://github.com/onlyoffice-testing-robot/onlyoffice_s3_wrapper
-  revision: dee91db8f20cb10cdd3002b11e558167d61ec5dd
-  specs:
-    onlyoffice_s3_wrapper (0.3.0)
-      aws-sdk-s3 (= 1.81.0)
-      onlyoffice_file_helper (= 0.3.0)
-
-GIT
   remote: https://github.com/onlyoffice-testing-robot/onlyoffice_tcm_helper
   revision: 24d8daebd8102bc443ef31dd3a42a471e2e21c43
   specs:
@@ -33,13 +25,13 @@ GEM
     aws-sdk-kms (1.38.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.81.0)
+    aws-sdk-s3 (1.79.1)
       aws-sdk-core (~> 3, >= 3.104.3)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    diff-lcs (1.3)
+    diff-lcs (1.4.4)
     jmespath (1.4.0)
     mini_portile2 (2.4.0)
     nokogiri (1.10.10)
@@ -48,6 +40,9 @@ GEM
       onlyoffice_logger_helper (~> 1)
       rubyzip (>= 1, < 3)
     onlyoffice_logger_helper (1.0.3)
+    onlyoffice_s3_wrapper (0.2.0)
+      aws-sdk-s3 (= 1.79.1)
+      onlyoffice_file_helper (= 0.3.0)
     ooxml_parser (0.9.1)
       nokogiri (~> 1.6)
       ruby-filemagic (~> 0.1)
@@ -63,15 +58,15 @@ GEM
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.0)
-      rspec-support (~> 3.9.0)
-    rspec-expectations (3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.0)
+    rspec-support (3.9.3)
     rubocop (0.91.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
@@ -81,7 +76,7 @@ GEM
       rubocop-ast (>= 0.4.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.4.0)
+    rubocop-ast (0.4.1)
       parser (>= 2.7.1.4)
     ruby-filemagic (0.7.2)
     ruby-progressbar (1.10.1)
@@ -93,7 +88,7 @@ PLATFORMS
 
 DEPENDENCIES
   onlyoffice_logger_helper
-  onlyoffice_s3_wrapper!
+  onlyoffice_s3_wrapper (= 0.2.0)
   onlyoffice_tcm_helper!
   ooxml_parser
   palladium!


### PR DESCRIPTION
because in 0.3.0 using environment variable with keys has been deprecated, but it is using in current project.

I will up version after change this functions