### PR TITLE
Add using files with keys instead of using environment variable only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.6.0
 ENV S3_KEY ""
 ENV S3_PRIVATE_KEY ""
 ENV PALLADIUM_TOKEN ""
-
+RUN mkdir -pv ~/.s3 && echo $S3_KEY > ~/.s3/key && echo $S3_PRIVATE_KEY > ~/.s3/private_key
 RUN apt update && apt install -y libmagic-dev
 RUN gem install bundler
 RUN gem update --system

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM ruby:2.6.0
 ENV S3_KEY ""
 ENV S3_PRIVATE_KEY ""
 ENV PALLADIUM_TOKEN ""
-RUN mkdir -pv ~/.s3 && echo $S3_KEY > ~/.s3/key && echo $S3_PRIVATE_KEY > ~/.s3/private_key
+RUN mkdir -pv ~/.s3 && \
+    echo $S3_KEY > ~/.s3/key && \
+    echo $S3_PRIVATE_KEY > ~/.s3/private_key
 RUN apt update && apt install -y libmagic-dev
 RUN gem install bundler
 RUN gem update --system


### PR DESCRIPTION
It is need because in 0.3.0. s3_wrapper version, using environment variables has depricated. See [release note](https://github.com/ONLYOFFICE-QA/onlyoffice_s3_wrapper/blob/master/CHANGELOG.md)